### PR TITLE
Fix function name typo

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -26,7 +26,7 @@ const saucers = [
 ]
 
 /* document.querySelector('.btn--txt').textContent = saucers[0].name; */
-function genarateSelectableSaucers(saucers, containerId) {
+function generateSelectableSaucers(saucers, containerId) {
     const getContainer = document.getElementById(containerId);
     const getTemplate = getContainer.querySelector('template');
     saucers.forEach(saucer => {
@@ -39,7 +39,7 @@ function genarateSelectableSaucers(saucers, containerId) {
     });
 }
 
-genarateSelectableSaucers(saucers,'food-items');
+generateSelectableSaucers(saucers,'food-items');
 
 
 


### PR DESCRIPTION
## Summary
- rename `genarateSelectableSaucers` to `generateSelectableSaucers`
- update call site accordingly

## Testing
- `grep -R "genarateSelectableSaucers" -n`

------
https://chatgpt.com/codex/tasks/task_e_68452dc7d5d4832db0b236e79a9eeccc